### PR TITLE
feat(frontend): add automated WhatsApp booking form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.next/

--- a/apps/frontend/app/auth/login/page.tsx
+++ b/apps/frontend/app/auth/login/page.tsx
@@ -1,12 +1,12 @@
 'use client';
-import { useState } from 'react';
+import { useState, FormEvent } from 'react';
 
 export default function Login() {
   const [email, setEmail] = useState('admin@example.com');
   const [password, setPassword] = useState('admin123');
   const [message, setMessage] = useState('');
 
-  const onSubmit = async (e) => {
+  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const api = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
     const res = await fetch(`${api}/auth/login`, {

--- a/apps/frontend/app/auth/register/page.tsx
+++ b/apps/frontend/app/auth/register/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState } from 'react';
+import { useState, FormEvent } from 'react';
 
 export default function Register() {
   const [email, setEmail] = useState('user@example.com');
@@ -7,7 +7,7 @@ export default function Register() {
   const [fullName, setFullName] = useState('User');
   const [message, setMessage] = useState('');
 
-  const onSubmit = async (e) => {
+  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const api = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
     const res = await fetch(`${api}/auth/register`, {

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -1,4 +1,6 @@
-export default function RootLayout({ children }) {
+import type { ReactNode } from 'react';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body style={{ fontFamily: 'sans-serif', margin: 0 }}>

--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -1,10 +1,115 @@
+"use client";
+
+import Image from 'next/image';
+import { useState, type ChangeEvent, type FormEvent } from 'react';
+
 export default function Home() {
+  const [form, setForm] = useState({
+    location: '',
+    hotel: '',
+    checkIn: '',
+    checkOut: '',
+    persons: 1,
+    phone: '',
+    score: 70
+  });
+
+  function handleChange(e: ChangeEvent<HTMLInputElement>) {
+    const { name, value } = e.target;
+    setForm(prev => ({ ...prev, [name]: value }));
+  }
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (Number(form.score) < 70) {
+      alert('Lead score must be at least 70 to trigger automation.');
+      return;
+    }
+    const msg = `Location: ${form.location}%0AHotel: ${form.hotel}%0ADates: ${form.checkIn} to ${form.checkOut}%0APersons: ${form.persons}%0APhone: ${form.phone}`;
+    window.open(`https://wa.me/201091474206?text=${msg}`, '_blank');
+  }
+
   return (
-    <main style={{ display: 'grid', placeItems: 'center', height: '100vh', gap: 16 }}>
-      <div>
+    <main style={{ display: 'grid', placeItems: 'center', minHeight: '100vh', gap: 16 }}>
+      <div style={{ textAlign: 'center' }}>
+        <Image
+          src="/hero.svg"
+          alt="Colorful placeholder"
+          width={600}
+          height={400}
+          style={{
+            borderRadius: 8,
+            boxShadow: '0 4px 8px rgba(0,0,0,0.1)',
+            marginBottom: 16
+          }}
+        />
         <h1>EgySaaS</h1>
         <p>Starter template is running.</p>
         <a href="/auth/login">Login</a> &nbsp;|&nbsp; <a href="/auth/register">Register</a>
+
+        <form onSubmit={handleSubmit} style={{ marginTop: 24, display: 'grid', gap: 8 }}>
+          <input
+            name="location"
+            value={form.location}
+            onChange={handleChange}
+            placeholder="Location"
+            required
+          />
+          <input
+            name="hotel"
+            value={form.hotel}
+            onChange={handleChange}
+            placeholder="Hotel"
+            required
+          />
+          <input
+            type="date"
+            name="checkIn"
+            value={form.checkIn}
+            onChange={handleChange}
+            required
+          />
+          <input
+            type="date"
+            name="checkOut"
+            value={form.checkOut}
+            onChange={handleChange}
+            required
+          />
+          <input
+            type="number"
+            name="persons"
+            value={form.persons}
+            onChange={handleChange}
+            min={1}
+            placeholder="Number of persons"
+            required
+          />
+          <input
+            type="tel"
+            name="phone"
+            value={form.phone}
+            onChange={handleChange}
+            placeholder="Contact number"
+            required
+          />
+          <input
+            type="number"
+            name="score"
+            value={form.score}
+            onChange={handleChange}
+            min={0}
+            max={100}
+            placeholder="Lead score"
+          />
+          <button type="submit">Send via WhatsApp</button>
+        </form>
+        <p style={{ marginTop: 8 }}>
+          Or chat directly on{' '}
+          <a href="https://wa.me/201091474206" target="_blank" rel="noopener noreferrer">
+            WhatsApp
+          </a>
+        </p>
       </div>
     </main>
   );

--- a/apps/frontend/next-env.d.ts
+++ b/apps/frontend/next-env.d.ts
@@ -1,2 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/frontend/next.config.js
+++ b/apps/frontend/next.config.js
@@ -1,5 +1,4 @@
-/********** @type {import('next').NextConfig} **********/
-const nextConfig = {
-  experimental: { appDir: true }
-};
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
 module.exports = nextConfig;

--- a/apps/frontend/public/hero.svg
+++ b/apps/frontend/public/hero.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400" viewBox="0 0 600 400">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#4f46e5"/>
+      <stop offset="100%" stop-color="#06b6d4"/>
+    </linearGradient>
+  </defs>
+  <rect width="600" height="400" fill="url(#g)"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="sans-serif" font-size="48" fill="#fff">EgySaaS</text>
+</svg>

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -12,8 +16,21 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- add booking form with location, hotel, dates, headcount, and phone fields
- trigger WhatsApp automation when lead score is at least 70
- link to WhatsApp chat for direct contact

## Testing
- ❌ `npm test` (Missing script "test")
- ⚠️ `npm run lint` (requires interactive setup)
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b145ac3d9c8325947e378f5120ebf3