### PR TITLE
Handle missing backend health response

### DIFF
--- a/apps/agents/orchestrator.py
+++ b/apps/agents/orchestrator.py
@@ -32,11 +32,20 @@ class Executor:
                 # call backend celery task through a faux endpoint (health ping here as demo)
                 try:
                     r = await client.get(f"{BACKEND}/health")
-                    r.raise_for_status()
-                    health = r.json()
-                except (httpx.HTTPError, ValueError) as exc:
-                    logger.warning("backend health check failed: %s", exc)
+                except httpx.RequestError as exc:
+                    logger.warning("backend health check request failed: %s", exc)
                     return {"status": "ok"}
+
+                if not r.is_success:
+                    logger.warning("backend health check returned %s", r.status_code)
+                    return {"status": "ok"}
+
+                try:
+                    health = r.json()
+                except ValueError as exc:
+                    logger.warning("backend health check invalid JSON: %s", exc)
+                    return {"status": "ok"}
+
                 return {"status": "ok", "health": health}
             return {"status": "noop"}
 

--- a/apps/agents/orchestrator.py
+++ b/apps/agents/orchestrator.py
@@ -2,6 +2,8 @@ import os, asyncio, httpx, logging
 from pydantic import BaseModel
 
 BACKEND = os.getenv("AGENTS_BACKEND_URL", "http://backend:8000")
+
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 class Task(BaseModel):
@@ -32,12 +34,14 @@ class Executor:
                 # call backend celery task through a faux endpoint (health ping here as demo)
                 try:
                     r = await client.get(f"{BACKEND}/health")
+                    r.raise_for_status()
                 except httpx.RequestError as exc:
                     logger.warning("backend health check request failed: %s", exc)
                     return {"status": "ok"}
-
-                if not r.is_success:
-                    logger.warning("backend health check returned %s", r.status_code)
+                except httpx.HTTPStatusError as exc:
+                    logger.warning(
+                        "backend health check returned %s", exc.response.status_code
+                    )
                     return {"status": "ok"}
 
                 try:

--- a/apps/agents/orchestrator.py
+++ b/apps/agents/orchestrator.py
@@ -1,9 +1,12 @@
-import os, asyncio, httpx, logging
+import asyncio
+import logging
+import os
+
+import httpx
 from pydantic import BaseModel
 
 BACKEND = os.getenv("AGENTS_BACKEND_URL", "http://backend:8000")
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 class Task(BaseModel):
@@ -66,4 +69,5 @@ async def main():
         print("[agents] Step:", step, "=>", result)
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     asyncio.run(main())

--- a/apps/agents/orchestrator.py
+++ b/apps/agents/orchestrator.py
@@ -29,8 +29,12 @@ class Executor:
                 return {"status": "ok"}
             if step == "trigger_welcome_email":
                 # call backend celery task through a faux endpoint (health ping here as demo)
-                r = await client.get(f"{BACKEND}/health")
-                return {"status": "ok", "health": r.json()}
+                try:
+                    r = await client.get(f"{BACKEND}/health")
+                    health = r.json()
+                except (httpx.HTTPError, ValueError):
+                    health = {"error": "unreachable"}
+                return {"status": "ok", "health": health}
             return {"status": "noop"}
 
 async def main():

--- a/apps/agents/orchestrator.py
+++ b/apps/agents/orchestrator.py
@@ -1,7 +1,8 @@
-import os, asyncio, httpx
+import os, asyncio, httpx, logging
 from pydantic import BaseModel
 
 BACKEND = os.getenv("AGENTS_BACKEND_URL", "http://backend:8000")
+logger = logging.getLogger(__name__)
 
 class Task(BaseModel):
     type: str
@@ -31,9 +32,11 @@ class Executor:
                 # call backend celery task through a faux endpoint (health ping here as demo)
                 try:
                     r = await client.get(f"{BACKEND}/health")
+                    r.raise_for_status()
                     health = r.json()
-                except (httpx.HTTPError, ValueError):
-                    health = {"error": "unreachable"}
+                except (httpx.HTTPError, ValueError) as exc:
+                    logger.warning("backend health check failed: %s", exc)
+                    return {"status": "ok"}
                 return {"status": "ok", "health": health}
             return {"status": "noop"}
 


### PR DESCRIPTION
## Summary
- handle unreachable backend health endpoint in agents orchestrator

## Testing
- `python apps/agents/orchestrator.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1d8cf1bd8832594bebae1c6549ba8