### PR TITLE
Use shared settings in seed script

### DIFF
--- a/apps/backend/app/api/routes/auth.py
+++ b/apps/backend/app/api/routes/auth.py
@@ -2,7 +2,6 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, EmailStr
 from sqlalchemy.orm import Session
 
-from app.db.session import SessionLocal
 from app.db import models
 from app.core.security import verify_password, get_password_hash, create_access_token
 from app.api.deps import get_db, get_current_user

--- a/apps/backend/app/scripts/seed_admin.py
+++ b/apps/backend/app/scripts/seed_admin.py
@@ -1,10 +1,12 @@
-import os
 from sqlalchemy.orm import Session
 from sqlalchemy import create_engine
 from app.db.models import User
 from app.core.security import get_password_hash
+from app.core.config import settings
 
-DATABASE_URL = os.environ.get("DATABASE_URL")
+DATABASE_URL = settings.DATABASE_URL
+if not DATABASE_URL:
+    raise RuntimeError("DATABASE_URL is not configured")
 engine = create_engine(DATABASE_URL, pool_pre_ping=True)
 
 def seed():


### PR DESCRIPTION
## Summary
- Use central config for database URL in admin seeding script
- Remove unused import from auth route

## Testing
- `pytest`
- `python -m py_compile apps/backend/app/scripts/seed_admin.py apps/backend/app/api/routes/auth.py`


------
https://chatgpt.com/codex/tasks/task_e_68b579bdf384832588a446a32d4a44fb