### PR TITLE
Handle comma separated CORS origins

### DIFF
--- a/apps/backend/app/core/config.py
+++ b/apps/backend/app/core/config.py
@@ -16,12 +16,13 @@ class Settings(BaseSettings):
     @classmethod
     def assemble_cors(cls, v):
         if isinstance(v, str):
-            # Allow JSON-like list in env
+            # Allow JSON-formatted lists or comma-separated strings in env
             try:
                 import json
                 return json.loads(v)
             except Exception:
-                return [v]
+                # Fallback to comma-separated list
+                return [i.strip() for i in v.split(",") if i.strip()]
         return v
 
     model_config = SettingsConfigDict(env_file=".env")


### PR DESCRIPTION
## Summary
- allow `BACKEND_CORS_ORIGINS` to parse comma-separated strings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5e0c8866c832590213b9cfc3b0835