### PR TITLE
chore(security): add scanning workflows and local scan script

### DIFF
--- a/.github/workflows/auto-hardening.yml
+++ b/.github/workflows/auto-hardening.yml
@@ -1,0 +1,54 @@
+name: Auto Hardening Bot
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  harden:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Apply security headers & .gitignore if missing
+        run: |
+          set -euo pipefail
+
+          mkdir -p .github
+
+          # vercel.json with strict headers (idempotent)
+          cat > vercel.json <<'EOJSON'
+          {
+            "version": 2,
+            "headers": [
+              {
+                "source": "/(.*)",
+                "headers": [
+                  { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains; preload" },
+                  { "key": "X-Frame-Options", "value": "DENY" },
+                  { "key": "X-Content-Type-Options", "value": "nosniff" },
+                  { "key": "Referrer-Policy", "value": "no-referrer" },
+                  { "key": "Permissions-Policy", "value": "geolocation=(), microphone=(), camera=(), payment=()" },
+                  { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https:;" }
+                ]
+              }
+            ]
+          }
+          EOJSON
+
+          # Minimal .gitignore (append if not exists)
+          if [ ! -f .gitignore ]; then
+            printf '%s\n' ".DS_Store" "node_modules/" "dist/" "build/" ".env" >> .gitignore
+          fi
+
+      - name: Create PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: security/hardening-bot
+          title: "chore(security): apply strict headers & .gitignore"
+          commit-message: "chore(security): apply strict headers & .gitignore"
+          body: "Auto hardening: adds vercel.json headers + basic .gitignore"
+          labels: security, automation

--- a/.github/workflows/pr-security.yml
+++ b/.github/workflows/pr-security.yml
@@ -1,0 +1,150 @@
+name: PR Security Deep Scan
+
+on:
+  pull_request:
+    branches: [ main, master ]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  deep-security:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # -------- GITLEAKS (secrets) --------
+      - name: Gitleaks (detect secrets)
+        id: gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        continue-on-error: true
+        with:
+          args: detect --source . --no-git --report-format json --report-path gitleaks.json --exit-code 1
+
+      # -------- SEMGREP (SAST) --------
+      - name: Semgrep (SAST)
+        id: semgrep
+        uses: returntocorp/semgrep-action@v1
+        continue-on-error: true
+        with:
+          config: p/ci
+          generateSarif: true
+          sarifFile: semgrep.sarif
+
+      - name: Upload Semgrep SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: semgrep.sarif
+        continue-on-error: true
+
+      # -------- TRIVY (deps & images) --------
+      - name: Trivy FS scan (critical/high)
+        id: trivy
+        uses: aquasecurity/trivy-action@0.20.0
+        continue-on-error: true
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: json
+          output: trivy.json
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: CRITICAL,HIGH
+
+      # -------- Dependency Review (GitHub native) --------
+      - name: Dependency Review (PR changes)
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+        continue-on-error: true
+
+      # -------- Compute repo fingerprint (hash) --------
+      - name: Compute repository fingerprint
+        id: fingerprint
+        run: |
+          set -euo pipefail
+          find . -type f -not -path "./.git/*" -print0 \
+            | sort -z \
+            | xargs -0 shasum -a 256 \
+            | shasum -a 256 \
+            | awk '{print $1}' > repo.hash
+          echo "hash=$(cat repo.hash)" >> $GITHUB_OUTPUT
+
+      # -------- Score & Summary --------
+      - name: Score & Summary
+        id: score
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Prepare jq
+          sudo apt-get update -y && sudo apt-get install -y jq >/dev/null
+
+          # Parse Gitleaks
+          GITLEAKS_FOUND=0
+          if [ -s gitleaks.json ]; then
+            GITLEAKS_FOUND=$(jq 'length' gitleaks.json || echo 0)
+          fi
+
+          # Parse Trivy
+          TRIVY_CRITICAL=0
+          TRIVY_HIGH=0
+          if [ -s trivy.json ]; then
+            TRIVY_CRITICAL=$(jq '[..|.Severity?//empty | select(.=="CRITICAL")] | length' trivy.json || echo 0)
+            TRIVY_HIGH=$(jq '[..|.Severity?//empty | select(.=="HIGH")] | length' trivy.json || echo 0)
+          fi
+
+          # Parse Semgrep SARIF (count high/critical by rule severity if present)
+          SEMGREP_HIGH=0
+          if [ -s semgrep.sarif ]; then
+            SEMGREP_HIGH=$(jq '[.runs[].results[]? | .level?] | map(select(.=="error")) | length' semgrep.sarif || echo 0)
+          fi
+
+          SCORE=3
+          CLASS="SECURE"
+          REASONS=()
+
+          if [ "$GITLEAKS_FOUND" -gt 0 ] || [ "$TRIVY_CRITICAL" -gt 0 ]; then
+            SCORE=1
+            CLASS="OFFLINE"
+            REASONS+=("Secrets or CRITICAL vulns found")
+          elif [ "$TRIVY_HIGH" -gt 0 ] || [ "$SEMGREP_HIGH" -gt 0 ]; then
+            SCORE=2
+            CLASS="WARNING"
+            REASONS+=("HIGH vulns or SAST errors")
+          fi
+
+          # verdict.json
+          printf '%s\n' \
+          "{ \"score\": $SCORE, \"classification\": \"$CLASS\", \"reasons\": $(printf '%s\n' \"$(printf '%s\n' \"${REASONS[@]:-}\" | jq -R . | jq -s .)\"), \"repo_hash\": \"${{ steps.fingerprint.outputs.hash }}\", \"gitleaks\": $GITLEAKS_FOUND, \"trivy_critical\": $TRIVY_CRITICAL, \"trivy_high\": $TRIVY_HIGH, \"semgrep_high\": $SEMGREP_HIGH, \"timestamp\": \"$(date -u +%FT%TZ)\" }" \
+          > verdict.json
+
+          {
+            echo "## 🔐 PR Security Deep Scan"
+            echo ""
+            echo "**Score:** $SCORE  |  **Class:** \`$CLASS\`"
+            echo ""
+            echo "- Secrets (gitleaks): **$GITLEAKS_FOUND**"
+            echo "- Trivy: CRITICAL **$TRIVY_CRITICAL**, HIGH **$TRIVY_HIGH**"
+            echo "- Semgrep (level=error): **$SEMGREP_HIGH**"
+            echo "- Repo hash: \`${{ steps.fingerprint.outputs.hash }}\`"
+            if [ "${#REASONS[@]}" -gt 0 ]; then
+              echo ""
+              echo "**Reasons:**"
+              for r in "${REASONS[@]}"; do echo "- $r"; done
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload artifacts (verdict & hash & logs)
+        uses: actions/upload-artifact@v4
+        with:
+          name: deep-security-artifacts
+          path: |
+            verdict.json
+            repo.hash
+            gitleaks.json
+            trivy.json
+            semgrep.sarif

--- a/.github/workflows/weekly-scan.yml
+++ b/.github/workflows/weekly-scan.yml
@@ -1,0 +1,40 @@
+name: Weekly Baseline Security Scan
+
+on:
+  schedule:
+    - cron: "0 3 * * 1"  # كل اثنين 03:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  weekly:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Gitleaks quick scan
+        uses: gitleaks/gitleaks-action@v2
+        continue-on-error: true
+        with:
+          args: detect --source . --no-git --report-format json --report-path gitleaks.json --exit-code 1
+
+      - name: Trivy quick scan
+        uses: aquasecurity/trivy-action@0.20.0
+        continue-on-error: true
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: table
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: CRITICAL,HIGH
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: weekly-security
+          path: |
+            gitleaks.json

--- a/scripts/deep_scan_local.sh
+++ b/scripts/deep_scan_local.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo "🔍 Local Deep Scan - $(date)"
+
+# Install deps (Ubuntu/Codespaces)
+if command -v apt-get >/dev/null 2>&1; then
+  sudo apt-get update -y
+  sudo apt-get install -y jq
+fi
+
+# Gitleaks via docker (portable)
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker not found; skipping docker-based gitleaks."
+else
+  docker run --rm -v "$PWD":/repo zricethezav/gitleaks:latest \
+    detect --source=/repo --no-git --report-format json --report-path /repo/gitleaks.local.json --exit-code 1 \
+    || echo "[!] Gitleaks found secrets (exit non-zero)"
+fi
+
+# Node deps scan (if package.json)
+if [ -f package.json ]; then
+  if ! command -v npm >/dev/null 2>&1; then
+    echo "npm not found; skip npm audit"
+  else
+    npm audit --audit-level=high || true
+  fi
+fi
+
+# Repo fingerprint
+find . -type f -not -path "./.git/*" -print0 | sort -z | xargs -0 shasum -a 256 | shasum -a 256 | awk '{print $1}' > repo.local.hash
+echo "Repo hash: $(cat repo.local.hash)"
+
+echo "✅ Local scan done."


### PR DESCRIPTION
## Summary
- add PR Security Deep Scan workflow with gitleaks, semgrep, trivy, fingerprinting and scoring
- schedule weekly baseline security scan
- add optional auto-hardening bot for headers and .gitignore
- include local deep scan helper script

## Testing
- `bash scripts/deep_scan_local.sh` *(fails: 403 Forbidden from apt repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68bbdd2ca92c832580c7de221112a79f